### PR TITLE
feat: enhance huber list API with default createdAt desc ordering

### DIFF
--- a/src/hubers/hubers.service.ts
+++ b/src/hubers/hubers.service.ts
@@ -53,10 +53,11 @@ export class HubersService {
               : undefined,
         },
         orderBy:
-          sortOptions &&
-          sortOptions.map((sortOption) => ({
-            [sortOption.sortBy]: sortOption.order,
-          })),
+          sortOptions && sortOptions.length > 0
+            ? sortOptions.map((sortOption) => ({
+                [sortOption.sortBy]: sortOption.order,
+              }))
+            : [{ createdAt: 'desc' }],
         include: {
           humanBookTopic: {
             include: {


### PR DESCRIPTION
## Summary
- Add default `orderBy: [{ createdAt: 'desc' }]` to `queryHubers()` in `HubersService`
- Previously, when no `sortOptions` were passed the query had no ordering — results were non-deterministic
- Custom `sortOptions` from the caller still take precedence when provided
- Tested in LOCAL:
<img width="1036" height="738" alt="Screenshot 2026-05-16 at 19 33 27" src="https://github.com/user-attachments/assets/dde62af9-9d87-4638-9eb5-37c5832cb2ec" />


Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)