### PR TITLE
feat: add topic color/status with role-based access, fix hardcoded ad…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8229,7 +8229,7 @@
       "version": "1.7.23",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.7.23.tgz",
       "integrity": "sha512-VDNkpDvDlreGh2E3tlDj8B3piiuLhhQA/7rIVZpiLUvG1YpucAa6N7iDXA7Gc/+Hah8spaCg/qvEaBkCmcIYCQ==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8271,7 +8271,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8288,7 +8287,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8305,7 +8303,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -8322,7 +8319,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8339,7 +8335,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8356,7 +8351,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8373,7 +8367,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8390,7 +8383,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8407,7 +8399,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8424,7 +8415,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8438,13 +8428,13 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@swc/types": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.12.tgz",
       "integrity": "sha512-wBJA+SdtkbFhHjTMYH+dEH1y4VpfGdAc2Kw/LK09i9bXd/K6j6PkDcFCEzb6iVfZMkPRrl/q0e3toqTAJdkIVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -8614,18 +8604,6 @@
       "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
       "dependencies": {
         "@types/ms": "*"
-      }
-    },
-    "node_modules/@types/eslint": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.0.tgz",
-      "integrity": "sha512-35EhHNOXgxnUgh4XCJsGhE7zdlDhYDN/aMG6UbkByCFFNgQ7b3U+uVoqBpicFydR8JEfgdjCF7SJ7MiJfzuiTA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
       }
     },
     "node_modules/@types/estree": {

--- a/prisma/migrations/20260521120000_add_color_to_topics/migration.sql
+++ b/prisma/migrations/20260521120000_add_color_to_topics/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "TopicColor" AS ENUM ('yellow', 'orange', 'pink', 'lavender', 'green', 'blue', 'primary');
+
+-- AlterTable
+ALTER TABLE "topics" ADD COLUMN "color" "TopicColor" NOT NULL DEFAULT 'primary';

--- a/prisma/migrations/20260521130000_add_status_to_topics/migration.sql
+++ b/prisma/migrations/20260521130000_add_status_to_topics/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "TopicStatus" AS ENUM ('active', 'inactive');
+
+-- AlterTable: existing rows become active; new app creates default to inactive
+ALTER TABLE "topics" ADD COLUMN "status" "TopicStatus" NOT NULL DEFAULT 'active';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,9 +81,26 @@ model status {
   stickers sticker[]
 }
 
+enum TopicColor {
+  yellow
+  orange
+  pink
+  lavender
+  green
+  blue
+  primary
+}
+
+enum TopicStatus {
+  active
+  inactive
+}
+
 model topics {
   id        Int                    @id @default(autoincrement())
   name      String                 @unique @db.VarChar
+  color     TopicColor             @default(primary)
+  status    TopicStatus            @default(inactive)
   createdAt DateTime               @default(now()) @db.Timestamp(6)
   updatedAt DateTime               @default(now()) @db.Timestamp(6)
   hubers    humanBookTopic[]

--- a/src/appeals/appeals.service.ts
+++ b/src/appeals/appeals.service.ts
@@ -78,12 +78,15 @@ export class AppealsService {
       },
     });
 
-    await this.notificationsService.pushNoti({
-      senderId: userId,
-      recipientId: 1,
-      type: NotificationTypeEnum.userAppeal,
-      relatedEntityId: appeal.id,
-    });
+    const adminId = await this.notificationsService.getAdminId();
+    if (adminId) {
+      await this.notificationsService.pushNoti({
+        senderId: userId,
+        recipientId: adminId,
+        type: NotificationTypeEnum.userAppeal,
+        relatedEntityId: appeal.id,
+      });
+    }
 
     return appeal;
   }
@@ -134,12 +137,15 @@ export class AppealsService {
       });
     }
 
-    await this.notificationsService.pushNoti({
-      senderId: 1,
-      recipientId: appeal.userId,
-      type: NotificationTypeEnum.appealResponse,
-      relatedEntityId: appealId,
-    });
+    const adminId = await this.notificationsService.getAdminId();
+    if (adminId) {
+      await this.notificationsService.pushNoti({
+        senderId: adminId,
+        recipientId: appeal.userId,
+        type: NotificationTypeEnum.appealResponse,
+        relatedEntityId: appealId,
+      });
+    }
 
     return updatedAppeal;
   }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -693,7 +693,7 @@ export class AuthService {
       throw new NotFoundException();
     }
     createHumanBooksDto.topics?.forEach(async (topic) => {
-      await this.topicsService.findOne(topic.id);
+      await this.topicsService.findOne(topic.id, user);
     });
 
     // TODO: check if user has already a human book

--- a/src/casl/ability.factory.ts
+++ b/src/casl/ability.factory.ts
@@ -9,6 +9,7 @@ import {
 import { Injectable } from '@nestjs/common';
 
 import { RoleEnum } from '@roles/roles.enum';
+import { TopicStatus } from '@topics/topic-status.enum';
 import { User } from '@users/domain/user';
 
 export enum Action {
@@ -116,8 +117,8 @@ export class CaslAbilityFactory {
       (subject: any) => subject.humanBookId === user.id,
     );
 
-    // Topics
-    can(Action.Read, 'Topic');
+    // Topics (active only)
+    can(Action.Read, 'Topic', { status: TopicStatus.active });
 
     // Time slots
     can([Action.Create, Action.Read, Action.Update, Action.Delete], 'TimeSlot');
@@ -160,8 +161,8 @@ export class CaslAbilityFactory {
     // Stories (read only)
     can(Action.Read, 'Story');
 
-    // Topics
-    can(Action.Read, 'Topic');
+    // Topics (active only)
+    can(Action.Read, 'Topic', { status: TopicStatus.active });
 
     // Story reviews
     can(
@@ -201,8 +202,8 @@ export class CaslAbilityFactory {
       'topics',
     ]);
 
-    // Topics
-    can(Action.Read, 'Topic');
+    // Topics (active only)
+    can(Action.Read, 'Topic', { status: TopicStatus.active });
 
     // Cannot update user
     cannot(Action.Update, 'User');

--- a/src/casl/services/permission.service.ts
+++ b/src/casl/services/permission.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { CaslAbilityFactory, Action } from '../ability.factory';
 import { User } from '@users/domain/user';
+import { TopicStatus } from '@topics/topic-status.enum';
 
 @Injectable()
 export class PermissionService {
@@ -69,6 +70,21 @@ export class PermissionService {
    */
   isAdmin(user: User): boolean {
     return user.role?.id === 1; // RoleEnum.admin
+  }
+
+  canManageTopics(user: User): boolean {
+    const ability = this.abilityFactory.defineAbilitiesFor(user);
+    return (
+      ability.can(Action.Manage, 'all') || ability.can(Action.Manage, 'Topic')
+    );
+  }
+
+  canReadTopic(user: User, topic: { status: TopicStatus }): boolean {
+    if (this.canManageTopics(user)) {
+      return true;
+    }
+
+    return topic.status === TopicStatus.active;
   }
 
   /**

--- a/src/database/seeds/relational/topic/topic-seed.service.ts
+++ b/src/database/seeds/relational/topic/topic-seed.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { faker } from '@faker-js/faker';
 import { PrismaService } from '@prisma-client/prisma-client.service';
+import { TopicColor } from '@topics/topic-color.enum';
+import { TopicStatus } from '@topics/topic-status.enum';
 
 @Injectable()
 export class TopicSeedService {
@@ -15,6 +17,8 @@ export class TopicSeedService {
           await this.prisma.topics.create({
             data: {
               name: faker.book.genre(),
+              color: faker.helpers.enumValue(TopicColor),
+              status: TopicStatus.active,
             },
           });
         }),

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -522,7 +522,6 @@ export class MailService {
       locale?: string;
     };
   }): Promise<void> {
-    
     const locale = mailData.data.locale || 'vi';
 
     const [title, subTitle, dear, p1, p2, p3, p4, p5] = await Promise.all([

--- a/src/moderations/moderations.service.ts
+++ b/src/moderations/moderations.service.ts
@@ -303,12 +303,15 @@ export class ModerationsService {
         reportId: dto.reportId,
       });
 
-      await this.notificationsService.pushNoti({
-        senderId: 1,
-        recipientId: dto.userId,
-        type: NotificationTypeEnum.huberWarning,
-        relatedEntityId: moderation.id,
-      });
+      const adminId = await this.notificationsService.getAdminId();
+      if (adminId) {
+        await this.notificationsService.pushNoti({
+          senderId: adminId,
+          recipientId: dto.userId,
+          type: NotificationTypeEnum.huberWarning,
+          relatedEntityId: moderation.id,
+        });
+      }
 
       return moderation;
     } catch (error) {

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, BadRequestException, Logger } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
 
 import { PrismaService } from '@prisma-client/prisma-client.service';
 import { infinityPagination } from '@utils/infinity-pagination';
 import { IPaginationOptions } from '@utils/types/pagination-options';
+import { RoleEnum } from '@roles/roles.enum';
 
 import { FindQueryNotificationsDto } from './dto/find-all-notifications-query.dto';
 import { CreateNotificationDto } from './dto/create-notification.dto';
@@ -519,22 +520,39 @@ export class NotificationsService {
     };
   }
 
-  async pushNoti(createNotificationDto: CreateNotificationDto) {
-    const notification = await this.create(createNotificationDto);
+  async getAdminId(): Promise<number | null> {
+    const admin = await this.prisma.user.findFirst({
+      where: { role: { id: RoleEnum.admin } },
+      select: { id: true },
+    });
+    return admin?.id ?? null;
+  }
 
-    if (notification) {
-      const refetchedNotifs = await this.findAllWithPagination({
-        filterOptions: { recipientId: notification.recipientId },
-        paginationOptions: { page: 1, limit: 5 },
-      });
+  pushNoti(createNotificationDto: CreateNotificationDto): void {
+    this.eventEmitter.emit('notification.create', createNotificationDto);
+  }
 
-      this.eventEmitter.emit('notification.list.fetch', {
-        userId: notification.recipientId,
-        notifications: {
-          ...refetchedNotifs,
-          ...infinityPagination(refetchedNotifs.data, { page: 1, limit: 5 }),
-        },
-      });
+  @OnEvent('notification.create')
+  async handleNotificationCreate(payload: CreateNotificationDto) {
+    try {
+      const notification = await this.create(payload);
+
+      if (notification) {
+        const refetchedNotifs = await this.findAllWithPagination({
+          filterOptions: { recipientId: notification.recipientId },
+          paginationOptions: { page: 1, limit: 5 },
+        });
+
+        this.eventEmitter.emit('notification.list.fetch', {
+          userId: notification.recipientId,
+          notifications: {
+            ...refetchedNotifs,
+            ...infinityPagination(refetchedNotifs.data, { page: 1, limit: 5 }),
+          },
+        });
+      }
+    } catch (error) {
+      this.logger.error(`Notification creation failed: ${error.message}`);
     }
   }
 }

--- a/src/reading-sessions/reading-sessions.processor.ts
+++ b/src/reading-sessions/reading-sessions.processor.ts
@@ -39,18 +39,21 @@ export class ReadingSessionsProcessor {
       });
     }
 
-    await this.notificationsService.pushNoti({
-      senderId: 1,
-      recipientId: session.humanBookId,
-      type: NotificationTypeEnum.other,
-      relatedEntityId: sessionId,
-    });
-    await this.notificationsService.pushNoti({
-      senderId: 1,
-      recipientId: session.readerId,
-      type: NotificationTypeEnum.other,
-      relatedEntityId: sessionId,
-    });
+    const adminId = await this.notificationsService.getAdminId();
+    if (adminId) {
+      await this.notificationsService.pushNoti({
+        senderId: adminId,
+        recipientId: session.humanBookId,
+        type: NotificationTypeEnum.other,
+        relatedEntityId: sessionId,
+      });
+      await this.notificationsService.pushNoti({
+        senderId: adminId,
+        recipientId: session.readerId,
+        type: NotificationTypeEnum.other,
+        relatedEntityId: sessionId,
+      });
+    }
   }
 
   @Process('send-booking-email')

--- a/src/reading-sessions/reading-sessions.service.ts
+++ b/src/reading-sessions/reading-sessions.service.ts
@@ -245,12 +245,15 @@ export class ReadingSessionsService {
     }
 
     if (dto.sessionStatus === 'finished') {
-      await this.notificationService.pushNoti({
-        senderId: 1,
-        recipientId: session.readerId,
-        type: NotificationTypeEnum.sessionFinish,
-        relatedEntityId: session.id,
-      });
+      const adminId = await this.notificationService.getAdminId();
+      if (adminId) {
+        await this.notificationService.pushNoti({
+          senderId: adminId,
+          recipientId: session.readerId,
+          type: NotificationTypeEnum.sessionFinish,
+          relatedEntityId: session.id,
+        });
+      }
     }
 
     if (session.sessionStatus === ReadingSessionStatus.FINISHED) {
@@ -450,12 +453,15 @@ export class ReadingSessionsService {
           data: { sessionStatus: ReadingSessionStatus.MISSED },
         });
 
-        await this.notificationService.pushNoti({
-          senderId: 1,
-          recipientId: session.readerId,
-          type: NotificationTypeEnum.missReadingSession,
-          relatedEntityId: session.id,
-        });
+        const adminId = await this.notificationService.getAdminId();
+        if (adminId) {
+          await this.notificationService.pushNoti({
+            senderId: adminId,
+            recipientId: session.readerId,
+            type: NotificationTypeEnum.missReadingSession,
+            relatedEntityId: session.id,
+          });
+        }
 
         this.logger.log(`[CRON] Marked session ${session.id} as MISSED`);
       }

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -67,12 +67,15 @@ export class ReportsService {
       },
     });
 
-    await this.notificationsService.pushNoti({
-      senderId: reporterId,
-      recipientId: 1,
-      type: NotificationTypeEnum.huberReported,
-      relatedEntityId: report.id,
-    });
+    const adminId = await this.notificationsService.getAdminId();
+    if (adminId) {
+      await this.notificationsService.pushNoti({
+        senderId: reporterId,
+        recipientId: adminId,
+        type: NotificationTypeEnum.huberReported,
+        relatedEntityId: report.id,
+      });
+    }
 
     return report;
   }

--- a/src/stories/stories.service.ts
+++ b/src/stories/stories.service.ts
@@ -30,7 +30,6 @@ import { FileConfig, FileDriver } from '@files/config/file-config.type';
 import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { FileType } from '@files/domain/file';
-import { RoleEnum } from '@roles/roles.enum';
 import { StoryQueryTypeEnum } from '@stories/story-query-type.enum';
 
 @Injectable()
@@ -72,12 +71,15 @@ export class StoriesService {
       topics: topicsEntities,
     });
 
-    await this.notifsService.pushNoti({
-      senderId: Number(humanBook.id),
-      recipientId: 1,
-      type: NotificationTypeEnum.publishStory,
-      relatedEntityId: newStory.id,
-    });
+    const adminId = await this.notifsService.getAdminId();
+    if (adminId) {
+      await this.notifsService.pushNoti({
+        senderId: Number(humanBook.id),
+        recipientId: adminId,
+        type: NotificationTypeEnum.publishStory,
+        relatedEntityId: newStory.id,
+      });
+    }
 
     return newStory;
   }
@@ -106,15 +108,12 @@ export class StoriesService {
       topics: topicsEntities,
     });
 
-    const admin = await this.prisma.user.findFirst({
-      where: { role: { id: RoleEnum.admin } },
-      select: { id: true },
-    });
+    const adminId = await this.notifsService.getAdminId();
 
-    if (admin) {
+    if (adminId) {
       await this.notifsService.pushNoti({
         senderId: Number(userId),
-        recipientId: admin.id,
+        recipientId: adminId,
         type: NotificationTypeEnum.account,
       });
     }
@@ -306,24 +305,30 @@ export class StoriesService {
       !!updateStoriesDto.publishStatus &&
       updateStoriesDto.publishStatus === 'published'
     ) {
-      await this.notifsService.pushNoti({
-        senderId: 1,
-        recipientId: story.humanBookId,
-        type: NotificationTypeEnum.publishStory,
-        relatedEntityId: story.id,
-      });
+      const adminId = await this.notifsService.getAdminId();
+      if (adminId) {
+        await this.notifsService.pushNoti({
+          senderId: adminId,
+          recipientId: story.humanBookId,
+          type: NotificationTypeEnum.publishStory,
+          relatedEntityId: story.id,
+        });
+      }
     }
 
     if (
       !!updateStoriesDto.publishStatus &&
       updateStoriesDto.publishStatus === 'rejected'
     ) {
-      await this.notifsService.pushNoti({
-        senderId: 1,
-        recipientId: story.humanBookId,
-        type: NotificationTypeEnum.rejectStory,
-        relatedEntityId: story.id,
-      });
+      const adminId = await this.notifsService.getAdminId();
+      if (adminId) {
+        await this.notifsService.pushNoti({
+          senderId: adminId,
+          recipientId: story.humanBookId,
+          type: NotificationTypeEnum.rejectStory,
+          relatedEntityId: story.id,
+        });
+      }
     }
 
     return updated;

--- a/src/topics/domain/topics.ts
+++ b/src/topics/domain/topics.ts
@@ -1,4 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { TopicColor } from '@topics/topic-color.enum';
+import { TopicStatus } from '@topics/topic-status.enum';
+
 export class Topic {
   @ApiProperty({
     type: Number,
@@ -7,6 +10,18 @@ export class Topic {
 
   @ApiProperty()
   name: string;
+
+  @ApiProperty({
+    enum: TopicColor,
+    example: TopicColor.primary,
+  })
+  color: TopicColor;
+
+  @ApiProperty({
+    enum: TopicStatus,
+    example: TopicStatus.inactive,
+  })
+  status: TopicStatus;
 
   @ApiProperty()
   createdAt: Date;

--- a/src/topics/dto/create-topics.dto.ts
+++ b/src/topics/dto/create-topics.dto.ts
@@ -1,5 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { TopicColor } from '@topics/topic-color.enum';
+import { TopicStatus } from '@topics/topic-status.enum';
 
 export class CreateTopicsDto {
   @ApiProperty({
@@ -9,4 +11,26 @@ export class CreateTopicsDto {
   @IsString()
   @IsNotEmpty()
   name: string;
+
+  @ApiProperty({
+    enum: TopicColor,
+    example: TopicColor.primary,
+    description: 'Preset color for the topic tag preview',
+    required: false,
+    default: TopicColor.primary,
+  })
+  @IsOptional()
+  @IsEnum(TopicColor)
+  color?: TopicColor;
+
+  @ApiProperty({
+    enum: TopicStatus,
+    example: TopicStatus.inactive,
+    description: 'New topics default to inactive until activated by admin',
+    required: false,
+    default: TopicStatus.inactive,
+  })
+  @IsOptional()
+  @IsEnum(TopicStatus)
+  status?: TopicStatus;
 }

--- a/src/topics/dto/topic.dto.ts
+++ b/src/topics/dto/topic.dto.ts
@@ -1,7 +1,24 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Topics } from '../domain/topics';
+import { TopicColor } from '@topics/topic-color.enum';
+import { TopicStatus } from '@topics/topic-status.enum';
 
 export class TopicDto implements Partial<Topics> {
   @ApiProperty()
   id: number;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty({
+    enum: TopicColor,
+    example: TopicColor.primary,
+  })
+  color: TopicColor;
+
+  @ApiProperty({
+    enum: TopicStatus,
+    example: TopicStatus.inactive,
+  })
+  status: TopicStatus;
 }

--- a/src/topics/infrastructure/persistence/relational/entities/topics.entity.ts
+++ b/src/topics/infrastructure/persistence/relational/entities/topics.entity.ts
@@ -12,6 +12,8 @@ import { ApiProperty } from '@nestjs/swagger';
 import { UserEntity } from '@users/infrastructure/persistence/relational/entities/user.entity';
 import { StoryEntity } from '@stories/infrastructure/persistence/relational/entities/story.entity';
 import { Exclude } from 'class-transformer';
+import { TopicColor } from '@topics/topic-color.enum';
+import { TopicStatus } from '@topics/topic-status.enum';
 
 @Entity({
   name: 'topics',
@@ -24,6 +26,30 @@ export class TopicsEntity extends EntityRelationalHelper {
   @ApiProperty()
   @Column({ unique: true })
   name: string;
+
+  @ApiProperty({
+    enum: TopicColor,
+    example: TopicColor.primary,
+  })
+  @Column({
+    type: 'enum',
+    enum: TopicColor,
+    nullable: false,
+    default: TopicColor.primary,
+  })
+  color: TopicColor;
+
+  @ApiProperty({
+    enum: TopicStatus,
+    example: TopicStatus.inactive,
+  })
+  @Column({
+    type: 'enum',
+    enum: TopicStatus,
+    nullable: false,
+    default: TopicStatus.inactive,
+  })
+  status: TopicStatus;
 
   @ApiProperty()
   @CreateDateColumn()

--- a/src/topics/infrastructure/persistence/relational/mappers/topics.mapper.ts
+++ b/src/topics/infrastructure/persistence/relational/mappers/topics.mapper.ts
@@ -1,11 +1,15 @@
 import { Topics } from '@topics/domain/topics';
 import { TopicsEntity } from '@topics/infrastructure/persistence/relational/entities/topics.entity';
+import { TopicColor } from '@topics/topic-color.enum';
+import { TopicStatus } from '@topics/topic-status.enum';
 
 export class TopicsMapper {
   static toDomain(raw: TopicsEntity): Topics {
     const domainEntity = new Topics();
     domainEntity.id = raw.id;
     domainEntity.name = raw.name;
+    domainEntity.color = raw.color;
+    domainEntity.status = raw.status;
     domainEntity.createdAt = raw.createdAt;
     domainEntity.updatedAt = raw.updatedAt;
 
@@ -20,6 +24,8 @@ export class TopicsMapper {
     persistenceEntity.createdAt = domainEntity.createdAt;
     persistenceEntity.updatedAt = domainEntity.updatedAt;
     persistenceEntity.name = domainEntity.name;
+    persistenceEntity.color = domainEntity.color ?? TopicColor.primary;
+    persistenceEntity.status = domainEntity.status ?? TopicStatus.inactive;
     return persistenceEntity;
   }
 }

--- a/src/topics/infrastructure/persistence/relational/repositories/topics.repository.ts
+++ b/src/topics/infrastructure/persistence/relational/repositories/topics.repository.ts
@@ -8,6 +8,7 @@ import { TopicsRepository } from '@topics/infrastructure/persistence/topics.repo
 import { TopicsMapper } from '@topics/infrastructure/persistence/relational/mappers/topics.mapper';
 import { IPaginationOptions } from '@utils/types/pagination-options';
 import { PublishStatus } from '@stories/status.enum';
+import { TopicStatus } from '@topics/topic-status.enum';
 
 @Injectable()
 export class TopicsRelationalRepository implements TopicsRepository {
@@ -27,15 +28,18 @@ export class TopicsRelationalRepository implements TopicsRepository {
   async findAllWithPagination({
     paginationOptions,
     name,
+    status,
   }: {
     paginationOptions: IPaginationOptions;
     name?: string;
+    status?: Topics['status'];
   }): Promise<Topics[]> {
     const entities = await this.topicsRepository.find({
       skip: (paginationOptions.page - 1) * paginationOptions.limit,
       take: paginationOptions.limit,
       where: {
         name: name ? Like(`%${name}%`) : undefined,
+        status: status ?? undefined,
       },
     });
 
@@ -47,7 +51,10 @@ export class TopicsRelationalRepository implements TopicsRepository {
       .createQueryBuilder('topic')
       .leftJoin('topic.stories', 'story') // join through storyTopic
       .leftJoin('story.readingSessions', 'rs') // join reading sessions
-      .where('story.publishStatus = :status', {
+      .where('topic.status = :topicStatus', {
+        topicStatus: TopicStatus.active,
+      })
+      .andWhere('story.publishStatus = :status', {
         status: PublishStatus.published,
       })
       .select('topic.id', 'id')
@@ -73,6 +80,23 @@ export class TopicsRelationalRepository implements TopicsRepository {
       where: { id },
     });
 
+    return entity ? TopicsMapper.toDomain(entity) : null;
+  }
+
+  async findByName(
+    name: string,
+    excludeId?: Topics['id'],
+  ): Promise<NullableType<Topics>> {
+    const trimmedName = name.trim();
+    const queryBuilder = this.topicsRepository
+      .createQueryBuilder('topic')
+      .where('LOWER(topic.name) = LOWER(:name)', { name: trimmedName });
+
+    if (excludeId !== undefined) {
+      queryBuilder.andWhere('topic.id != :excludeId', { excludeId });
+    }
+
+    const entity = await queryBuilder.getOne();
     return entity ? TopicsMapper.toDomain(entity) : null;
   }
 

--- a/src/topics/infrastructure/persistence/topics.repository.ts
+++ b/src/topics/infrastructure/persistence/topics.repository.ts
@@ -11,14 +11,21 @@ export abstract class TopicsRepository {
   abstract findAllWithPagination({
     paginationOptions,
     name,
+    status,
   }: {
     paginationOptions: IPaginationOptions;
     name?: string;
+    status?: Topics['status'];
   }): Promise<Topics[]>;
 
   abstract findTop3PopularTopics(): Promise<Topics[]>;
 
   abstract findById(id: Topics['id']): Promise<NullableType<Topics>>;
+
+  abstract findByName(
+    name: string,
+    excludeId?: Topics['id'],
+  ): Promise<NullableType<Topics>>;
 
   abstract update(
     id: Topics['id'],

--- a/src/topics/topic-color.enum.ts
+++ b/src/topics/topic-color.enum.ts
@@ -1,0 +1,9 @@
+export enum TopicColor {
+  yellow = 'yellow',
+  orange = 'orange',
+  pink = 'pink',
+  lavender = 'lavender',
+  green = 'green',
+  blue = 'blue',
+  primary = 'primary',
+}

--- a/src/topics/topic-status.enum.ts
+++ b/src/topics/topic-status.enum.ts
@@ -1,0 +1,4 @@
+export enum TopicStatus {
+  active = 'active',
+  inactive = 'inactive',
+}

--- a/src/topics/topics.controller.ts
+++ b/src/topics/topics.controller.ts
@@ -8,9 +8,12 @@ import {
   Patch,
   Post,
   Query,
+  Request,
+  UseGuards,
 } from '@nestjs/common';
 import { TopicsService } from './topics.service';
 import {
+  ApiBearerAuth,
   ApiCreatedResponse,
   ApiOkResponse,
   ApiOperation,
@@ -28,8 +31,13 @@ import { CreateTopicsDto } from './dto/create-topics.dto';
 import { TopicDto } from './dto/topic.dto';
 import { UpdateTopicsDto } from './dto/update-topics.dto';
 import { TopicQueryTypeEnum } from '@topics/topic-query-type.enum';
+import { AuthGuard } from '@nestjs/passport';
+import { CheckAbilities } from '@casl/decorators/casl.decorator';
+import { Action } from '@casl/ability.factory';
+import { CaslGuard } from '@casl/guards/casl.guard';
 
 @ApiTags('Topics')
+@ApiBearerAuth()
 @Controller({
   path: 'topics',
   version: '1',
@@ -38,6 +46,8 @@ export class TopicsController {
   constructor(private readonly topicsService: TopicsService) {}
 
   @Post()
+  @CheckAbilities((ability) => ability.can(Action.Manage, 'Topic'))
+  @UseGuards(AuthGuard('jwt'), CaslGuard)
   @ApiOperation({ summary: 'Create a new topic' })
   @ApiCreatedResponse({
     type: TopicDto,
@@ -47,10 +57,13 @@ export class TopicsController {
   }
 
   @Get()
+  @CheckAbilities((ability) => ability.can(Action.Read, 'Topic'))
+  @UseGuards(AuthGuard('jwt'), CaslGuard)
   @ApiOkResponse({
     type: InfinityPaginationResponse(Topics),
   })
   async findAll(
+    @Request() request,
     @Query() query: FindAllTopicsDto,
   ): Promise<InfinityPaginationResponseDto<Topics>> {
     if (query?.type === TopicQueryTypeEnum.MOST_POPULAR) {
@@ -75,12 +88,15 @@ export class TopicsController {
           limit,
         },
         name,
+        user: request.user,
       }),
       { page, limit },
     );
   }
 
   @Get(':id')
+  @CheckAbilities((ability) => ability.can(Action.Read, 'Topic'))
+  @UseGuards(AuthGuard('jwt'), CaslGuard)
   @ApiParam({
     name: 'id',
     type: Number,
@@ -89,11 +105,16 @@ export class TopicsController {
   @ApiOkResponse({
     type: TopicDto,
   })
-  async findOne(@Param('id') id: number): Promise<Topics | null> {
-    return await this.topicsService.findOne(id);
+  async findOne(
+    @Request() request,
+    @Param('id') id: number,
+  ): Promise<Topics | null> {
+    return await this.topicsService.findOne(id, request.user);
   }
 
   @Patch(':id')
+  @CheckAbilities((ability) => ability.can(Action.Manage, 'Topic'))
+  @UseGuards(AuthGuard('jwt'), CaslGuard)
   @ApiParam({
     name: 'id',
     type: Number,
@@ -107,6 +128,8 @@ export class TopicsController {
   }
 
   @Delete(':id')
+  @CheckAbilities((ability) => ability.can(Action.Manage, 'Topic'))
+  @UseGuards(AuthGuard('jwt'), CaslGuard)
   @ApiOperation({ summary: 'Delete a topic' })
   @ApiParam({
     name: 'id',

--- a/src/topics/topics.data.ts
+++ b/src/topics/topics.data.ts
@@ -1,33 +1,45 @@
 import { Topic } from './domain/topics';
+import { TopicColor } from './topic-color.enum';
+import { TopicStatus } from './topic-status.enum';
 
 export const topicsData: Topic[] = [
   {
     id: 1,
     name: 'Topic 1',
+    color: TopicColor.primary,
+    status: TopicStatus.active,
     createdAt: new Date(),
     updatedAt: new Date(),
   },
   {
     id: 2,
     name: 'Topic 2',
+    color: TopicColor.orange,
+    status: TopicStatus.active,
     createdAt: new Date(),
     updatedAt: new Date(),
   },
   {
     id: 3,
     name: 'Topic 3',
+    color: TopicColor.pink,
+    status: TopicStatus.inactive,
     createdAt: new Date(),
     updatedAt: new Date(),
   },
   {
     id: 4,
     name: 'Topic 4',
+    color: TopicColor.lavender,
+    status: TopicStatus.active,
     createdAt: new Date(),
     updatedAt: new Date(),
   },
   {
     id: 5,
     name: 'Topic 5',
+    color: TopicColor.green,
+    status: TopicStatus.inactive,
     createdAt: new Date(),
     updatedAt: new Date(),
   },

--- a/src/topics/topics.module.ts
+++ b/src/topics/topics.module.ts
@@ -3,8 +3,10 @@ import { TopicsService } from './topics.service';
 import { TopicsController } from './topics.controller';
 import { RelationalTopicsPersistenceModule } from './infrastructure/persistence/relational/relational-persistence.module';
 
+import { CaslModule } from '@casl/casl.module';
+
 @Module({
-  imports: [RelationalTopicsPersistenceModule],
+  imports: [RelationalTopicsPersistenceModule, CaslModule],
   controllers: [TopicsController],
   providers: [TopicsService],
   exports: [TopicsService, RelationalTopicsPersistenceModule],

--- a/src/topics/topics.service.ts
+++ b/src/topics/topics.service.ts
@@ -1,31 +1,62 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { CreateTopicsDto } from './dto/create-topics.dto';
 import { UpdateTopicsDto } from './dto/update-topics.dto';
 import { TopicsRepository } from './infrastructure/persistence/topics.repository';
 import { IPaginationOptions } from '@utils/types/pagination-options';
 import { Topics } from './domain/topics';
+import { TopicColor } from './topic-color.enum';
+import { TopicStatus } from './topic-status.enum';
+import { PermissionService } from '@casl/services/permission.service';
+import { User } from '@users/domain/user';
 
 @Injectable()
 export class TopicsService {
-  constructor(private readonly topicsRepository: TopicsRepository) {}
+  constructor(
+    private readonly topicsRepository: TopicsRepository,
+    private readonly permissionService: PermissionService,
+  ) {}
 
-  create(createTopicsDto: CreateTopicsDto) {
-    return this.topicsRepository.create(createTopicsDto);
+  async create(createTopicsDto: CreateTopicsDto) {
+    const name = createTopicsDto.name.trim();
+    const existing = await this.topicsRepository.findByName(name);
+
+    if (existing) {
+      throw new ConflictException(
+        'A topic with this name already exists (active or inactive)',
+      );
+    }
+
+    return this.topicsRepository.create({
+      name,
+      color: createTopicsDto.color ?? TopicColor.primary,
+      status: createTopicsDto.status ?? TopicStatus.inactive,
+    });
   }
 
   findAllWithPagination({
     paginationOptions,
     name,
+    user,
   }: {
     paginationOptions: IPaginationOptions;
     name?: string;
+    user: User;
   }) {
+    const status = this.permissionService.canManageTopics(user)
+      ? undefined
+      : TopicStatus.active;
+
     return this.topicsRepository.findAllWithPagination({
       paginationOptions: {
         page: paginationOptions.page,
         limit: paginationOptions.limit,
       },
       name,
+      status,
     });
   }
 
@@ -33,17 +64,34 @@ export class TopicsService {
     return this.topicsRepository.findTop3PopularTopics();
   }
 
-  async findOne(id: Topics['id']): Promise<Topics | null> {
+  async findOne(id: Topics['id'], user: User): Promise<Topics | null> {
     const topic = await this.topicsRepository.findById(id);
 
     if (!topic) {
       throw new NotFoundException('Topic not found');
     }
 
+    if (!this.permissionService.canReadTopic(user, topic)) {
+      throw new NotFoundException('Topic not found');
+    }
+
     return topic;
   }
 
-  update(id: Topics['id'], updateTopicsDto: UpdateTopicsDto) {
+  async update(id: Topics['id'], updateTopicsDto: UpdateTopicsDto) {
+    if (updateTopicsDto.name !== undefined) {
+      const name = updateTopicsDto.name.trim();
+      const existing = await this.topicsRepository.findByName(name, id);
+
+      if (existing) {
+        throw new ConflictException(
+          'A topic with this name already exists (active or inactive)',
+        );
+      }
+
+      updateTopicsDto = { ...updateTopicsDto, name };
+    }
+
     return this.topicsRepository.update(id, updateTopicsDto);
   }
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -514,6 +514,8 @@ export class UsersService {
   }
 
   async upgrade(id: User['id'], upgradeDto: UpgradeDto) {
+    const adminId = await this.notificationsService.getAdminId();
+
     if (upgradeDto.action === Action.accept) {
       await this.usersRepository.update(id, {
         role: {
@@ -521,11 +523,14 @@ export class UsersService {
         },
         approval: Approval.approved,
       });
-      await this.notificationsService.pushNoti({
-        senderId: 1,
-        recipientId: Number(id),
-        type: NotificationTypeEnum.account,
-      });
+
+      if (adminId) {
+        await this.notificationsService.pushNoti({
+          senderId: adminId,
+          recipientId: Number(id),
+          type: NotificationTypeEnum.account,
+        });
+      }
 
       // change status for the first story when becoming a human book
       await this.prisma.story.updateMany({
@@ -541,12 +546,14 @@ export class UsersService {
         approval: Approval.rejected,
       });
 
-      await this.notificationsService.pushNoti({
-        senderId: 1,
-        recipientId: Number(id),
-        type: NotificationTypeEnum.rejectHuber,
-        extraNote: upgradeDto.reason,
-      });
+      if (adminId) {
+        await this.notificationsService.pushNoti({
+          senderId: adminId,
+          recipientId: Number(id),
+          type: NotificationTypeEnum.rejectHuber,
+          extraNote: upgradeDto.reason,
+        });
+      }
 
       return {
         message: 'Reject request to become huber!',


### PR DESCRIPTION
…min ID

- Add TopicColor and TopicStatus enums with color/status columns to topics
- Admin can Manage all topics regardless of status; all other roles can only Read active topics
- Dynamically resolve admin user by role instead of hardcoded senderId/recipientId as 1
- Add case-insensitive duplicate name check for topic create and update
- Refactor pushNoti to fire-and-forget event pattern for non-blocking delivery
- Add CASL guards and permission checks on all topic controller endpoints

Ticket: https://github.com/hulib-engineering/hulib-services/issues/279