### PR TITLE
fix: filter out inactive topics when fetching huber card details

### DIFF
--- a/src/hubers/hubers.service.ts
+++ b/src/hubers/hubers.service.ts
@@ -15,6 +15,7 @@ import { AppConfig } from '@config/app-config.type';
 import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { omit } from 'lodash';
+import { TopicStatus } from '@topics/topic-status.enum';
 import { HuberWithRelations } from './dto/query-hubers-response.dto';
 
 @Injectable()
@@ -59,6 +60,11 @@ export class HubersService {
           })),
         include: {
           humanBookTopic: {
+            where: {
+              topic: {
+                status: TopicStatus.active,
+              },
+            },
             include: {
               topic: true,
             },
@@ -212,7 +218,16 @@ export class HubersService {
           : undefined,
       },
       include: {
-        humanBookTopic: true,
+        humanBookTopic: {
+          where: {
+            topic: {
+              status: TopicStatus.active,
+            },
+          },
+          include: {
+            topic: true,
+          },
+        },
         file: {
           select: {
             id: true,
@@ -239,6 +254,9 @@ export class HubersService {
         return {
           ...omit(huber, ['feedbackTos', 'feedbackBys']),
           file: await this.transformFileUrl(huber.file),
+          sharingTopics: huber.humanBookTopic.map((topic) => ({
+            ...topic.topic,
+          })),
           rating,
         };
       }),

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { PrismaService } from '@prisma-client/prisma-client.service';
 import { RoleEnum } from '@roles/roles.enum';
+import { TopicStatus } from '@topics/topic-status.enum';
 
 import { SearchDto } from './dto/search.dto';
 
@@ -50,7 +51,16 @@ export class SearchService {
         },
       },
       include: {
-        humanBookTopic: true,
+        humanBookTopic: {
+          where: {
+            topic: {
+              status: TopicStatus.active,
+            },
+          },
+          include: {
+            topic: true,
+          },
+        },
       },
     });
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -36,6 +36,7 @@ import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { AppConfig } from '@config/app-config.type';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { ReadingSessionStatus } from '@reading-sessions/domain';
+import { TopicStatus } from '@topics/topic-status.enum';
 import { omit } from 'lodash';
 
 @Injectable()
@@ -156,6 +157,11 @@ export class UsersService {
       },
       include: {
         humanBookTopic: {
+          where: {
+            topic: {
+              status: TopicStatus.active,
+            },
+          },
           include: {
             topic: {
               select: {


### PR DESCRIPTION
## Summary
- Inactive topics were incorrectly included in huber card responses because Prisma queries fetched `humanBookTopic` relations without filtering by `topic.status`
- Added `where: { topic: { status: TopicStatus.active } }` filters to all queries that include huber topics

## Changes
- **`src/hubers/hubers.service.ts`** — Fixed `queryHubers()` and `findRecommendedHubers()` to filter active topics; also add missing `sharingTopics` mapping in recommended hubers response
- **`src/users/users.service.ts`** — Fixed `findById()` (huber detail endpoint) to filter active topics
- **`src/search/search.service.ts`** — Fixed `searchByKeyword()` to filter active topics and include topic details

## Verified
- TypeScript typecheck: ✅
- Lint: ✅
- Tests: ✅