### PR TITLE
fix: include topic color in user detail response

### DIFF
--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -167,6 +167,7 @@ export class UsersService {
               select: {
                 id: true,
                 name: true,
+                color: true,
               },
             },
           },
@@ -177,6 +178,7 @@ export class UsersService {
               select: {
                 id: true,
                 name: true,
+                color: true,
               },
             },
           },


### PR DESCRIPTION
## Summary
- `GET /v1/users/:id` (findById) was missing `color` in topic select for both `humanBookTopic` and `topicsOfInterest`

## Changes
- Added `color: true` to topic selects in `users.service.ts` findById()

## Verified
- TypeScript typecheck: ✅
- Lint: ✅
- Tests: ✅