### PR TITLE
fix: remove expired reading session reminder notifications

### DIFF
--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -52,11 +52,13 @@ export class NotificationsService {
         where: {
           recipientId: filterOptions.recipientId,
           seen: false,
+          deletedAt: null,
         },
       }),
       this.prisma.notification.findMany({
         where: {
           ...filterOptions,
+          deletedAt: null,
         },
         orderBy: {
           createdAt: 'desc',
@@ -526,6 +528,21 @@ export class NotificationsService {
       select: { id: true },
     });
     return admin?.id ?? null;
+  }
+
+  async softDeleteSessionReminderNotification(
+    sessionId: number,
+  ): Promise<void> {
+    await this.prisma.notification.updateMany({
+      where: {
+        relatedEntityId: sessionId,
+        type: { name: 'other' },
+        deletedAt: null,
+      },
+      data: {
+        deletedAt: new Date(),
+      },
+    });
   }
 
   pushNoti(createNotificationDto: CreateNotificationDto): void {

--- a/src/reading-sessions/reading-sessions.service.ts
+++ b/src/reading-sessions/reading-sessions.service.ts
@@ -254,6 +254,7 @@ export class ReadingSessionsService {
           relatedEntityId: session.id,
         });
       }
+      await this.notificationService.softDeleteSessionReminderNotification(id);
     }
 
     if (session.sessionStatus === ReadingSessionStatus.FINISHED) {
@@ -452,6 +453,10 @@ export class ReadingSessionsService {
           where: { id: session.id },
           data: { sessionStatus: ReadingSessionStatus.MISSED },
         });
+
+        await this.notificationService.softDeleteSessionReminderNotification(
+          session.id,
+        );
 
         const adminId = await this.notificationService.getAdminId();
         if (adminId) {


### PR DESCRIPTION
Soft-delete `other`-type notifications when the linked reading session reaches `finished` or `missed` status. The notification list queries now filter out soft-deleted records so stale meeting reminders no longer appear to users.