### PR TITLE
fix: reorder StoriesModule before ContestReportModule for Swagger visibility

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -69,7 +69,6 @@ const infrastructureDatabaseModule = TypeOrmModule.forRootAsync({
 @Module({
   imports: [
     AppealsModule,
-    ContestReportModule,
     ReportsModule,
     SocketModule,
     NotificationsModule,
@@ -78,6 +77,7 @@ const infrastructureDatabaseModule = TypeOrmModule.forRootAsync({
     ScheduleModule.forRoot(),
     HealthcheckModule,
     StoriesModule,
+    ContestReportModule,
     FavStoriesModule,
     FavHubersModule,
     TopicsModule,


### PR DESCRIPTION
## Vấn đề
Module contest-report không hiển thị trong Swagger UI dù đã được import trong app.module.ts.

## Nguyên nhân
ContestReportModule phụ thuộc vào StoriesModule nhưng được import trước StoriesModule trong imports array của AppModule. Điều này khiến controller của contest-report không được NestJS register đúng cách, dẫn đến Swagger không detect được các endpoints.

## Fix
Hoán đổi thứ tự import: đưa StoriesModule lên trước ContestReportModule trong pp.module.ts.

## API endpoints (sau fix)
- \POST /api/v1/contest-report/generate\ - Tạo Excel report
- \GET /api/v1/contest-report/download/:filename\ - Download file
- \GET /api/v1/contest-report/download-latest?topic=\ - Download file mới nhất